### PR TITLE
Add ordered/book-mode support to writings collection

### DIFF
--- a/Website-v2/package.json
+++ b/Website-v2/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
-    "astro": "^6.0.8",
+    "astro": "^6.2.1",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-figure": "^1.0.1",
@@ -28,8 +28,8 @@
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.9.8",
-    "@types/node": "^25.5.0",
+    "@astrojs/check": "^0.9.9",
+    "@types/node": "^25.6.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }

--- a/Website-v2/public/admin/config.yml
+++ b/Website-v2/public/admin/config.yml
@@ -76,6 +76,7 @@ collections:
     sortable_fields: ['date', 'title']
     fields:
       - { label: Title, name: title, widget: string }
+      - { label: Subtitle, name: subtitle, widget: string, required: false }
       - { label: Description, name: description, widget: string, required: false }
       - label: Date
         name: date
@@ -88,6 +89,8 @@ collections:
       - { label: Tags, name: tags, widget: list, default: [] }
       - { label: Form, name: form, widget: select, required: false, options: [poem, essay, prose, story, other] }
       - { label: Collection, name: collection, widget: string, required: false, hint: "Optional. Group this entry under a named collection." }
+      - { label: Cover Image, name: cover, widget: image, required: false }
+      - { label: Order, name: order, widget: number, required: false, hint: "Used for sequential content like book chapters. Use 0 for the collection landing page (cover entry). Use 1, 2, 3... for chapters. Leave blank for standalone writings." }
       - { label: Body, name: body, widget: markdown }
   
   - name: writings-settings

--- a/Website-v2/src/components/writings/WritingsPostNav.astro
+++ b/Website-v2/src/components/writings/WritingsPostNav.astro
@@ -7,9 +7,10 @@ interface Props {
   nextPost?: CollectionEntry<"writings"> | null;
   collection: string | null;
   section: string;
+  postBasePath?: string;
 }
 
-const { prevPost = null, nextPost = null, collection, section } = Astro.props;
+const { prevPost = null, nextPost = null, collection, section, postBasePath = "/writings" } = Astro.props;
 
 const centerLabel = collection ? `All ${collection}` : "All other writings";
 const centerHref = collection ? `/${section}/collection/${collectionSlug(collection)}` : `/${section}/other`;
@@ -24,7 +25,7 @@ const centerHref = collection ? `/${section}/collection/${collectionSlug(collect
     <!-- Previous (older) -->
     <div class="bg-white dark:bg-gray-950 p-5">
       {prevPost ? (
-        <a href={`/writings/${prevPost.id}`} class="group block">
+        <a href={`${postBasePath}/${prevPost.id}`} class="group block">
           <span class="text-xs text-gray-400 dark:text-gray-500 uppercase tracking-wide font-medium">
             ← Previous
           </span>
@@ -55,7 +56,7 @@ const centerHref = collection ? `/${section}/collection/${collectionSlug(collect
     <!-- Next (newer) -->
     <div class="bg-white dark:bg-gray-950 p-5 md:text-right">
       {nextPost ? (
-        <a href={`/writings/${nextPost.id}`} class="group block">
+        <a href={`${postBasePath}/${nextPost.id}`} class="group block">
           <span class="text-xs text-gray-400 dark:text-gray-500 uppercase tracking-wide font-medium">
             Next →
           </span>

--- a/Website-v2/src/content.config.ts
+++ b/Website-v2/src/content.config.ts
@@ -62,6 +62,9 @@ const writings = defineCollection({
     tags: z.array(z.string()).default([]),
     collection: z.string().optional(),
     form: z.string().optional(),
+    cover: z.string().optional(),
+    subtitle: z.string().optional(),
+    order: z.number().optional(),
   }),
 });
 

--- a/Website-v2/src/layouts/WritingsLayout.astro
+++ b/Website-v2/src/layouts/WritingsLayout.astro
@@ -14,6 +14,7 @@ interface Props {
   nextPost?: CollectionEntry<"writings"> | null;
   currentCollection?: string | null;
   collection?: string | null;
+  postBasePath?: string;
 }
 
 const {
@@ -24,6 +25,7 @@ const {
   nextPost = null,
   currentCollection: propCollection = null,
   collection = null,
+  postBasePath,
 } = Astro.props;
 
 // Derive currentCollection from URL when not passed as prop.
@@ -122,7 +124,7 @@ const showPostNav = prevPost !== null || nextPost !== null;
         <slot />
       )}
 
-      {showPostNav && <WritingsPostNav prevPost={prevPost} nextPost={nextPost} collection={collection} section="writings" />}
+      {showPostNav && <WritingsPostNav prevPost={prevPost} nextPost={nextPost} collection={collection} section="writings" postBasePath={postBasePath} />}
     </div>
 
   </div>

--- a/Website-v2/src/modules/writings/cms.config.yml
+++ b/Website-v2/src/modules/writings/cms.config.yml
@@ -8,6 +8,7 @@
   sortable_fields: ['date', 'title']
   fields:
     - { label: Title, name: title, widget: string }
+    - { label: Subtitle, name: subtitle, widget: string, required: false }
     - { label: Description, name: description, widget: string, required: false }
     - label: Date
       name: date
@@ -20,6 +21,8 @@
     - { label: Tags, name: tags, widget: list, default: [] }
     - { label: Form, name: form, widget: select, required: false, options: [poem, essay, prose, story, other] }
     - { label: Collection, name: collection, widget: string, required: false, hint: "Optional. Group this entry under a named collection." }
+    - { label: Cover Image, name: cover, widget: image, required: false }
+    - { label: Order, name: order, widget: number, required: false, hint: "Used for sequential content like book chapters. Use 0 for the collection landing page (cover entry). Use 1, 2, 3... for chapters. Leave blank for standalone writings." }
     - { label: Body, name: body, widget: markdown }
 
 - name: writings-settings

--- a/Website-v2/src/modules/writings/cms.config.yml
+++ b/Website-v2/src/modules/writings/cms.config.yml
@@ -19,7 +19,7 @@
       default: ""
       picker_utc: false
     - { label: Tags, name: tags, widget: list, default: [] }
-    - { label: Form, name: form, widget: select, required: false, options: [poem, essay, prose, story, other] }
+    - { label: Form, name: form, widget: select, required: false, options: [poem, essay, prose, story, book, other] }
     - { label: Collection, name: collection, widget: string, required: false, hint: "Optional. Group this entry under a named collection." }
     - { label: Cover Image, name: cover, widget: image, required: false }
     - { label: Order, name: order, widget: number, required: false, hint: "Used for sequential content like book chapters. Use 0 for the collection landing page (cover entry). Use 1, 2, 3... for chapters. Leave blank for standalone writings." }

--- a/Website-v2/src/pages/writings/collection/[collection].astro
+++ b/Website-v2/src/pages/writings/collection/[collection].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, render } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import WritingsLayout from "../../../layouts/WritingsLayout.astro";
 import { collectionSlug } from "@/lib/collection";
@@ -17,10 +17,7 @@ export async function getStaticPaths() {
 
   return [...buckets.entries()].map(([slug, { label, entries }]) => ({
     params: { collection: slug },
-    props: {
-      label,
-      entries: entries.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf()),
-    },
+    props: { label, entries },
   }));
 }
 
@@ -30,46 +27,153 @@ interface Props {
 }
 
 const { label, entries } = Astro.props;
+
+const bookMode = entries.some((e) => e.data.order !== undefined);
+
+let CoverContent: any = null;
+let coverEntry: CollectionEntry<"writings"> | null = null;
+let tocEntries: CollectionEntry<"writings">[] = [];
+let unorderedEntries: CollectionEntry<"writings">[] = [];
+let genericEntries: CollectionEntry<"writings">[] = [];
+
+if (bookMode) {
+  coverEntry = entries.find((e) => e.data.order === 0) ?? null;
+  if (coverEntry) {
+    const rendered = await render(coverEntry);
+    CoverContent = rendered.Content;
+  }
+  tocEntries = entries
+    .filter((e) => e.data.order !== undefined && e.data.order >= 1)
+    .sort((a, b) => a.data.order! - b.data.order!);
+  unorderedEntries = entries
+    .filter((e) => e.data.order === undefined)
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+} else {
+  genericEntries = entries.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
 ---
 
 <WritingsLayout description={`Writings in the ${label} collection.`}>
   <section class="space-y-8">
-    <h1 class="text-3xl font-bold tracking-tight">{label}</h1>
-    {entries.length === 0 ? (
-      <p class="text-gray-500 dark:text-gray-400">No entries in this collection yet.</p>
-    ) : (
-      <ul class="space-y-6 divide-y divide-gray-100 dark:divide-gray-800">
-        {entries.map((entry) => (
-          <li class="pt-6 first:pt-0 space-y-1.5">
-            <a href={`/writings/${entry.id}`} class="group block space-y-1">
-              <h2 class="text-xl font-semibold group-hover:underline underline-offset-4">{entry.data.title}</h2>
-              <div class="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
-                <time datetime={entry.data.date.toISOString()}>
-                  {entry.data.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
-                </time>
-                {entry.data.form && <span>&middot; {entry.data.form}</span>}
-              </div>
-              {entry.data.description && (
-                <p class="text-gray-600 dark:text-gray-400">{entry.data.description}</p>
-              )}
-            </a>
-            {entry.data.tags.length > 0 && (
-              <ul class="flex flex-wrap gap-1.5">
-                {entry.data.tags.map((tag: string) => (
-                  <li>
-                    <a
-                      href={`/tags/${tag.toLowerCase().replace(/\s+/g, "-")}`}
-                      class="text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-2 py-0.5 rounded transition-colors"
-                    >
-                      {tag}
-                    </a>
-                  </li>
-                ))}
-              </ul>
+    {bookMode ? (
+      <>
+        {coverEntry ? (
+          <div class="space-y-4">
+            {coverEntry.data.cover && (
+              <img src={coverEntry.data.cover} alt={coverEntry.data.title} class="w-full rounded-lg object-cover max-h-96" />
             )}
-          </li>
-        ))}
-      </ul>
+            <h1 class="text-3xl font-bold tracking-tight">{coverEntry.data.title}</h1>
+            {coverEntry.data.subtitle && (
+              <p class="text-xl text-gray-500 dark:text-gray-400">{coverEntry.data.subtitle}</p>
+            )}
+            {CoverContent && (
+              <div class="prose dark:prose-invert max-w-none">
+                <CoverContent />
+              </div>
+            )}
+          </div>
+        ) : (
+          <h1 class="text-3xl font-bold tracking-tight">{label}</h1>
+        )}
+
+        {tocEntries.length > 0 && (
+          <div class="space-y-4">
+            <h2 class="text-2xl font-semibold">Table of Contents</h2>
+            <ol class="space-y-6 divide-y divide-gray-100 dark:divide-gray-800">
+              {tocEntries.map((entry) => (
+                <li class="pt-6 first:pt-0 space-y-1.5">
+                  <a href={`/writings/${entry.id}`} class="group block space-y-1">
+                    <h3 class="text-xl font-semibold group-hover:underline underline-offset-4">
+                      {entry.data.order}. {entry.data.title}
+                    </h3>
+                    {entry.data.description && (
+                      <p class="text-gray-600 dark:text-gray-400">{entry.data.description}</p>
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        {unorderedEntries.length > 0 && (
+          <div class="space-y-4">
+            <h2 class="text-2xl font-semibold">More</h2>
+            <ul class="space-y-6 divide-y divide-gray-100 dark:divide-gray-800">
+              {unorderedEntries.map((entry) => (
+                <li class="pt-6 first:pt-0 space-y-1.5">
+                  <a href={`/writings/${entry.id}`} class="group block space-y-1">
+                    <h2 class="text-xl font-semibold group-hover:underline underline-offset-4">{entry.data.title}</h2>
+                    <div class="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                      <time datetime={entry.data.date.toISOString()}>
+                        {entry.data.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+                      </time>
+                      {entry.data.form && <span>&middot; {entry.data.form}</span>}
+                    </div>
+                    {entry.data.description && (
+                      <p class="text-gray-600 dark:text-gray-400">{entry.data.description}</p>
+                    )}
+                  </a>
+                  {entry.data.tags.length > 0 && (
+                    <ul class="flex flex-wrap gap-1.5">
+                      {entry.data.tags.map((tag: string) => (
+                        <li>
+                          <a
+                            href={`/tags/${tag.toLowerCase().replace(/\s+/g, "-")}`}
+                            class="text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-2 py-0.5 rounded transition-colors"
+                          >
+                            {tag}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </>
+    ) : (
+      <>
+        <h1 class="text-3xl font-bold tracking-tight">{label}</h1>
+        {genericEntries.length === 0 ? (
+          <p class="text-gray-500 dark:text-gray-400">No entries in this collection yet.</p>
+        ) : (
+          <ul class="space-y-6 divide-y divide-gray-100 dark:divide-gray-800">
+            {genericEntries.map((entry) => (
+              <li class="pt-6 first:pt-0 space-y-1.5">
+                <a href={`/writings/${entry.id}`} class="group block space-y-1">
+                  <h2 class="text-xl font-semibold group-hover:underline underline-offset-4">{entry.data.title}</h2>
+                  <div class="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                    <time datetime={entry.data.date.toISOString()}>
+                      {entry.data.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+                    </time>
+                    {entry.data.form && <span>&middot; {entry.data.form}</span>}
+                  </div>
+                  {entry.data.description && (
+                    <p class="text-gray-600 dark:text-gray-400">{entry.data.description}</p>
+                  )}
+                </a>
+                {entry.data.tags.length > 0 && (
+                  <ul class="flex flex-wrap gap-1.5">
+                    {entry.data.tags.map((tag: string) => (
+                      <li>
+                        <a
+                          href={`/tags/${tag.toLowerCase().replace(/\s+/g, "-")}`}
+                          class="text-xs text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-2 py-0.5 rounded transition-colors"
+                        >
+                          {tag}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </>
     )}
   </section>
 </WritingsLayout>

--- a/Website-v2/src/pages/writings/collection/[collection]/[slug].astro
+++ b/Website-v2/src/pages/writings/collection/[collection]/[slug].astro
@@ -1,13 +1,19 @@
 ---
 import { getCollection, render, type CollectionEntry } from "astro:content";
-import WritingsLayout from "../../layouts/WritingsLayout.astro";
+import WritingsLayout from "../../../../layouts/WritingsLayout.astro";
 import { collectionSlug } from "@/lib/collection";
 
 export async function getStaticPaths() {
   const entries = await getCollection("writings");
   return entries
-    .filter((e) => e.data.order === undefined)
-    .map((entry) => ({ params: { slug: entry.id }, props: { entry } }));
+    .filter((e) => e.data.order !== undefined && e.data.order >= 1)
+    .map((entry) => ({
+      params: {
+        collection: collectionSlug(entry.data.collection!),
+        slug: entry.id,
+      },
+      props: { entry },
+    }));
 }
 
 interface Props {
@@ -17,14 +23,21 @@ interface Props {
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 
-// Scope prev/next to the same collection group (named collection or uncollected "other")
-const collectionKey = entry.data.collection ?? null;
-const scopedEntries = (await getCollection("writings"))
-  .filter((e) => (e.data.collection ?? null) === collectionKey && e.data.order === undefined)
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
-const index = scopedEntries.findIndex((e) => e.id === entry.id);
-const prevPost = scopedEntries.length > 1 ? (scopedEntries[index + 1] ?? null) : null; // older
-const nextPost = scopedEntries.length > 1 ? (scopedEntries[index - 1] ?? null) : null; // newer
+const colSlug = collectionSlug(entry.data.collection!);
+
+const scopedOrdered = (await getCollection("writings"))
+  .filter(
+    (e) =>
+      e.data.collection &&
+      collectionSlug(e.data.collection) === colSlug &&
+      e.data.order !== undefined &&
+      e.data.order >= 1,
+  )
+  .sort((a, b) => a.data.order! - b.data.order!);
+
+const index = scopedOrdered.findIndex((e) => e.id === entry.id);
+const prevPost = index > 0 ? scopedOrdered[index - 1] : null;
+const nextPost = index < scopedOrdered.length - 1 ? scopedOrdered[index + 1] : null;
 ---
 
 <WritingsLayout
@@ -33,9 +46,18 @@ const nextPost = scopedEntries.length > 1 ? (scopedEntries[index - 1] ?? null) :
   date={entry.data.date}
   prevPost={prevPost}
   nextPost={nextPost}
-  currentCollection={entry.data.collection ? collectionSlug(entry.data.collection) : "other"}
+  currentCollection={colSlug}
   collection={entry.data.collection ?? null}
+  postBasePath={`/writings/collection/${colSlug}`}
 >
+  <div class="not-prose mb-6">
+    <a
+      href={`/writings/collection/${colSlug}`}
+      class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+    >
+      ← {entry.data.collection}
+    </a>
+  </div>
   <Content />
   {entry.data.tags.length > 0 && (
     <div class="not-prose mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">


### PR DESCRIPTION
- Extend writings schema with cover, subtitle, and order fields
- [collection].astro: book mode (order fields present) renders cover entry, ToC sorted by order, then unordered extras; generic mode unchanged
- New nested route collection/[collection]/[slug].astro for ordered entries with order-ascending prev/next nav and collection back-link
- [slug].astro: exclude ordered entries (order field present) from flat route
- WritingsPostNav/WritingsLayout: thread postBasePath for nested route links
- Decap CMS: add subtitle, cover, order fields to writings module config
- Update packages: astro 6.2.1, @astrojs/check 0.9.9, @types/node 25.6.0; pin @tailwindcss/vite and tailwindcss at 4.2.2 (Vite 8 incompatibility)